### PR TITLE
Sql to ecto queries

### DIFF
--- a/lib/teachbase/accounts/user_token.ex
+++ b/lib/teachbase/accounts/user_token.ex
@@ -173,6 +173,7 @@ defmodule Teachbase.Accounts.UserToken do
   end
 
   def user_and_contexts_query(user, [_ | _] = contexts) do
-    from t in Teachbase.Accounts.UserToken, where: t.user_id == ^user.id and t.context in ^contexts
+    from t in Teachbase.Accounts.UserToken,
+      where: t.user_id == ^user.id and t.context in ^contexts
   end
 end

--- a/lib/teachbase/courses/lessons.ex
+++ b/lib/teachbase/courses/lessons.ex
@@ -2,13 +2,15 @@ defmodule Teachbase.Courses.Lesson do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Teachbase.Accounts.User, as: Teacher
+  alias Teachbase.Accounts.User
 
   schema "lessons" do
     field :description, :string
     field :name, :string
     field :reference, :string
-    belongs_to :teacher, Teacher
+
+    belongs_to :teacher, User
+    many_to_many :students, User, join_through: "lessons_students"
 
     timestamps()
   end
@@ -17,7 +19,7 @@ defmodule Teachbase.Courses.Lesson do
   def changeset(lessons, attrs) do
     lessons
     |> cast(attrs, [:name, :description, :reference])
-    |> cast_assoc(:teacher, with: &Teacher.registration_changeset/2)
+    |> cast_assoc(:teacher, with: &User.registration_changeset/2)
     |> validate_required([:name, :description, :reference, :teacher])
   end
 end

--- a/lib/teachbase_web/live/search_live.ex
+++ b/lib/teachbase_web/live/search_live.ex
@@ -1,0 +1,19 @@
+defmodule TeachbaseWeb.SearchLive do
+  use TeachbaseWeb, :live_view
+
+  alias Teachbase.Courses
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, text: "", lessons: [])}
+  end
+
+  def handle_event("search", %{"text" => text}, socket) do
+    case text do
+      "" ->
+        {:noreply, assign(socket, text: text, lessons: [])}
+
+      text ->
+        {:noreply, assign(socket, text: text, lessons: Courses.list_lessons_with_text(text))}
+    end
+  end
+end

--- a/lib/teachbase_web/live/search_live.html.heex
+++ b/lib/teachbase_web/live/search_live.html.heex
@@ -1,0 +1,22 @@
+<h1 align="center">Search</h1>
+
+<form phx-change="search">
+  <input type="text" name="text" value={@text} autofocus/>
+</form>
+
+<div id="lessons">
+  <%= for lesson <- @lessons do %>
+    <div id={"lesson-#{lesson.id}"}>
+      <p>
+        <b>Name:</b> <%= lesson.name %>
+      </p>
+      <p>
+        <b>Description:</b> <%= lesson.description %>
+      </p>
+      <p>
+        <b>Reference:</b> <%= lesson.reference %>
+      </p>
+      <hr>
+    </div>
+  <% end %>
+</div>

--- a/lib/teachbase_web/router.ex
+++ b/lib/teachbase_web/router.ex
@@ -21,6 +21,8 @@ defmodule TeachbaseWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :index
+
+    live "/search", SearchLive
   end
 
   # Other scopes may use custom stacks.
@@ -95,5 +97,4 @@ defmodule TeachbaseWeb.Router do
     get "/users/confirm/:token", UserConfirmationController, :edit
     post "/users/confirm/:token", UserConfirmationController, :update
   end
-
 end

--- a/lib/teachbase_web/templates/layout/root.html.heex
+++ b/lib/teachbase_web/templates/layout/root.html.heex
@@ -13,15 +13,12 @@
     <header>
       <section class="container">
         <nav>
-          <ul>
-            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li>
-            <%= if function_exported?(Routes, :live_dashboard_path, 2) do %>
-              <li><%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home) %></li>
-            <% end %>
-          </ul>
           <%= render "_user_menu.html", assigns %>
+
+          <a href="/search">Search</a>
         </nav>
-        <a href="https://phoenixframework.org/" class="phx-logo">
+        
+        <a href="/" class="phx-logo">
           <img src={Routes.static_path(@conn, "/images/phoenix.png")} alt="Phoenix Framework Logo"/>
         </a>
       </section>

--- a/priv/repo/migrations/20220121111731_create_lessons_students.exs
+++ b/priv/repo/migrations/20220121111731_create_lessons_students.exs
@@ -1,0 +1,12 @@
+defmodule Teachbase.Repo.Migrations.CreateLessonsStudents do
+  use Ecto.Migration
+
+  def change do
+    create table(:lessons_students) do
+      add :lesson_id, references(:lessons)
+      add :user_id, references(:users)
+    end
+
+    create unique_index(:lessons_students, [:lesson_id, :user_id])
+  end
+end

--- a/test/support/fixtures/courses_fixtures.ex
+++ b/test/support/fixtures/courses_fixtures.ex
@@ -14,7 +14,8 @@ defmodule Teachbase.CoursesFixtures do
         description: "some description",
         name: "some name",
         reference: "some reference",
-        teacher: Teachbase.AccountsFixtures.valid_user_attributes()
+        teacher: Teachbase.AccountsFixtures.valid_user_attributes(),
+        students: [Teachbase.AccountsFixtures.valid_user_attributes()]
       })
       |> Teachbase.Courses.create_lessons()
 

--- a/test/teachbase/courses_test.exs
+++ b/test/teachbase/courses_test.exs
@@ -21,7 +21,12 @@ defmodule Teachbase.CoursesTest do
     end
 
     test "create_lessons/1 with valid data creates a lessons" do
-      valid_attrs = %{description: "some description", name: "some name", reference: "some reference", teacher: Teachbase.AccountsFixtures.valid_user_attributes()}
+      valid_attrs = %{
+        description: "some description",
+        name: "some name",
+        reference: "some reference",
+        teacher: Teachbase.AccountsFixtures.valid_user_attributes()
+      }
 
       assert {:ok, %Lesson{} = lessons} = Courses.create_lessons(valid_attrs)
       assert lessons.description == "some description"
@@ -35,7 +40,12 @@ defmodule Teachbase.CoursesTest do
 
     test "update_lessons/2 with valid data updates the lessons" do
       lessons = lessons_fixture()
-      update_attrs = %{description: "some updated description", name: "some updated name", reference: "some updated reference"}
+
+      update_attrs = %{
+        description: "some updated description",
+        name: "some updated name",
+        reference: "some updated reference"
+      }
 
       assert {:ok, %Lesson{} = lessons} = Courses.update_lessons(lessons, update_attrs)
       assert lessons.description == "some updated description"

--- a/test/teachbase_web/controllers/lessons_controller_test.exs
+++ b/test/teachbase_web/controllers/lessons_controller_test.exs
@@ -40,7 +40,7 @@ defmodule TeachbaseWeb.LessonsControllerTest do
                "id" => ^id,
                "description" => "some description",
                "name" => "some name",
-               "reference" => "some reference",
+               "reference" => "some reference"
              } = json_response(conn, 200)["data"]
     end
 
@@ -63,7 +63,7 @@ defmodule TeachbaseWeb.LessonsControllerTest do
                "id" => ^id,
                "description" => "some updated description",
                "name" => "some updated name",
-               "reference" => "some updated reference",
+               "reference" => "some updated reference"
              } = json_response(conn, 200)["data"]
     end
 


### PR DESCRIPTION
**Перевести запросы с SQL на Ecto**

1. Добавить обратную ссылку `Lesson` `has_many` `Students`.
2. Выбрать всех учеников данного учителя.
3. Выбрать все лекции, в которых количество учеников превышает заранее заданное параметром число.
4. Выбрать все лекции, по заданному шаблону имени, со своим простейшим «языком регулярок».
5. Реализовать простейший интерактивный «поиск/фильтр», пользователь начинает вводить слово, и ему показывается все, что матчится.

_В последнем пункте сам элемент управления (`input`) можно не делать, достаточно эмулировать приход новой буквы через Liveview._